### PR TITLE
Implement capacity calculation and C-rate input.

### DIFF
--- a/bat_can_input.yaml
+++ b/bat_can_input.yaml
@@ -11,6 +11,9 @@ cell-description:
     surf-phase: 'anode_electrolyte' # Cantera phase name
     electrolyte-phase: 'electrolyte' # Cantera phase name
     conductor-phase: 'electron' # Cantera phase name
+    stored-ion: # Details on the stored species. Used for capacity calc.
+      name: Li[anode]
+      charge: 1
     thickness: 50e-6 # anode thickness, m
     r_p: 4e-6 # Particle radius, m
     phi_0: 0. # Initial electric potential, V
@@ -29,6 +32,9 @@ cell-description:
     surf-phase: 'cathode_electrolyte' # Cantera phase name
     electrolyte-phase: 'electrolyte' # Cantera phase name
     conductor-phase: 'electron' # Cantera phase name
+    stored-ion: # Details on the stored species. Used for capacity calc.
+      name: Li[cathode]
+      charge: 1
     thickness: 50e-6 # anode thickness, m
     r_p: 6e-6 # Particle radius, m
     phi_0: 4.125 # Initial electric potential, V
@@ -44,7 +50,7 @@ parameters:
   simulation:
     type: 'CC_cycle' # Constant current cycling
     # Specify only one of i_ext or C-rate. The other should be null:
-    i_ext: 0.01 A/cm2 # input current density, format: XX units. Units are 'current/area', with no carat for exponents (e.g. A/cm2)
+    i_ext: 0.001 A/cm2 # input current density, format: XX units. Units are 'current/area', with no carat for exponents (e.g. A/cm2)
     C-rate: null # input C-rate
     n_cycles: 10 # Number of cycles. Currently must be 0.5 or an int.
     first-step: 'discharge'  # Start with charge or discharge?

--- a/single_particle_electrode/initialize.py
+++ b/single_particle_electrode/initialize.py
@@ -27,6 +27,15 @@ def initialize(input_file, inputs, electrode_name, phi_elyte_0, params, offset):
         C_dl_Inv = 1/inputs['C_dl']
 
         SV_offset = offset
+
+        # Determine Capacity (Ah/m2)
+        X_o = bulk_obj.X # save initial X
+        bulk_obj.X = inputs['stored-ion']['name']+':1.0'
+        C = bulk_obj[inputs['stored-ion']['name']].concentrations[0]
+        
+        capacity = (C*inputs['stored-ion']['charge']*ct.faraday
+                *inputs['eps_solid'])*inputs['thickness']/3600
+        bulk_obj.X = X_o
             
         # State variables: electrode potential, electrolyte potential, 
         # electrode composition (nsp), electrolyte composition (nsp)

--- a/single_particle_electrode/residual.py
+++ b/single_particle_electrode/residual.py
@@ -10,6 +10,8 @@ def residual(SV, self, params):
     self.bulk_obj.electric_potential = phi_ed
     self.conductor_obj.electric_potential = phi_ed
     self.elyte_obj.electric_potential = phi_elyte
+
+    #TODO #18
     
     # Faradaic current density is positive when electrons are consumed 
     # (Li transferred to the anode)


### PR DESCRIPTION
Addresses #15.

- Anode and cathode capacities (Ah/m2) are calculated during initialize routine.
- Battery capacity is the minimum of anode and cathode capacity.
- Battery capacity is used to calculate the max simulation time.
- If user input is C-rate, it is multiplied by Battery capacity to find i_ext.