### PR TITLE
Update transport - added aliasing of diffusion coefficient scaling functions

### DIFF
--- a/inputs/Li_PorousSep_Sulfur.yaml
+++ b/inputs/Li_PorousSep_Sulfur.yaml
@@ -16,7 +16,7 @@ cell-description:
       charge: 1
     mobile-ion:  'Li+(e)' # Species name for Li+ in elyte.
     thickness: 8e-6 # Initial anode thickness, m
-    minimum-thickness: 1e-9 # minimum anode thickness, m 
+    minimum-thickness: 1e-9 # minimum anode thickness, m
     phi_0: 0. # Initial electric potential, V
     A_surf_ratio: 1.0 # Interface area per unit geometric area
     C_dl: 9e-6 #F/m2
@@ -30,7 +30,10 @@ cell-description:
     transport:
       mobile-ion:  'Li+(e)' # Species name for Li+ in elyte.
       model: 'dilute-solution'
-      diffusion-coefficients: # Species names must match those in the phase 
+      diffusion-scaling: 'ideal' # Model to scale diffusion coefficients by concentration
+      D_scale_coeff: 1e-11
+      flag_lithiated: 0
+      diffusion-coefficients: # Species names must match those in the phase
       #definition, below:
         - species: 'TEGDME(e)'
           D_k: 1e-12
@@ -63,7 +66,7 @@ cell-description:
       - bulk-name: "lithium_sulfide" # Cantera phase name
         surf-name: "lithium_sulfide_surf" # Cantera name for surface phase
     initial-state: # Determine initial state of electrode
-      method: "porosity" 
+      method: "porosity"
       eps_init:
         - phase: sulfur
           value: 0.12
@@ -97,7 +100,7 @@ parameters:
     C-rate: 0.1 # input C-rate
     n_cycles: 5 # Number of cycles. Currently must be 0.5 or an int.
     first-step: 'discharge'  # Start with charge or discharge?
-    equilibrate: 
+    equilibrate:
       enable: True # Start with a hold at open circuit?
       time: 100 # If true, how long is the hold, s
     phi-cutoff-lower: 3.4 # Simulation cuts off if E_Cell <= this value, V

--- a/separator_models/porous_separator.py
+++ b/separator_models/porous_separator.py
@@ -7,12 +7,12 @@
 import cantera as ct
 import numpy as np
 
-from submodels import transport 
+from submodels import transport
 
 class separator():
     # Initialize the model.
     def __init__(self, input_file, inputs, params, offset):
-    
+
         self.elyte_obj = ct.Solution(input_file, inputs['electrolyte-phase'])
 
         # State variables: electrolyte potential, electrolyte composition (nsp)
@@ -23,9 +23,13 @@ class separator():
         self.dyInv = 1 / self.dy
         self.eps_elyte = inputs['eps_electrolyte']
 
-        # Microstructure-based transport scaling factor, based on Bruggeman 
+        # Microstructure-based transport scaling factor, based on Bruggeman
         # coefficient of -0.5:
         self.elyte_microstructure = self.eps_elyte**1.5
+
+        self.flag_lithiated = inputs['transport']['flag_lithiated']
+
+        self.D_scale_coeff = inputs['transport']['D_scale_coeff']
 
         self.index_Li = \
             self.elyte_obj.species_index(inputs['transport']['mobile-ion'])
@@ -33,7 +37,7 @@ class separator():
         # Process transport inputs:
         if inputs['transport']['model']=='dilute-solution':
             # Import transport function:
-                       
+
             self.elyte_transport = transport.dilute_solution
             self.D_k = np.zeros_like(self.elyte_obj.X)
             for item in inputs['transport']['diffusion-coefficients']:
@@ -43,18 +47,25 @@ class separator():
             raise ValueError('Please specify a valid electrolyte transport ',
                 'model.')
 
+        if inputs['transport']['diffusion-scaling'] == 'ideal':
+            self.scale_diff = transport.scale_diff_ideal
+        elif inputs['transport']['diffusion-scaling'] == 'zhang':
+            self.scale_diff = transport.scale_diff_zhang
+        else:
+            raise ValueError('Please specify a valid diffusion scaling model')
+
         self.SV_offset = offset
 
         # Ionic conductivity of bulk electrolyte (S/m):
         self.sigma_io = inputs['sigma_io']
 
-        # This model produces two plots: Electric potential and Li 
+        # This model produces two plots: Electric potential and Li
         # concentration in the separator.
         self.n_plots = 2
 
         # Set Cantera object state:
         if 'X_0' in inputs:
-            self.elyte_obj.TPX = (params['T'], params['P'], 
+            self.elyte_obj.TPX = (params['T'], params['P'],
                 inputs['X_0'])
         else:
             self.elyte_obj.TP = params['T'], params['P']
@@ -63,25 +74,25 @@ class separator():
 
     def initialize(self, inputs):
         SV = np.zeros([self.n_points*self.n_vars])
-    
+
         # Set up pointers:
         self.SVptr = {}
-        self.SVptr['phi'] = np.arange(0,self.n_points * self.n_vars, 
+        self.SVptr['phi'] = np.arange(0,self.n_points * self.n_vars,
             self.n_vars, dtype='int')
 
-        self.SVptr['C_k_elyte'] = np.ndarray(shape=(self.n_points, 
-            self.elyte_obj.n_species), dtype='int')       
+        self.SVptr['C_k_elyte'] = np.ndarray(shape=(self.n_points,
+            self.elyte_obj.n_species), dtype='int')
         for i in range(self.n_points):
-            self.SVptr['C_k_elyte'][i,:] = range(1 + i*self.n_vars, 
+            self.SVptr['C_k_elyte'][i,:] = range(1 + i*self.n_vars,
                 1 + i*self.n_vars + self.elyte_obj.n_species)
-        
+
         # What portion of the SV represents the separator?
-        self.SVptr['sep'] = np.arange(self.SV_offset, 
+        self.SVptr['sep'] = np.arange(self.SV_offset,
             self.SV_offset + self.n_points*self.n_vars)
 
         self.SVnames = \
             (['phi_elyte']+ self.elyte_obj.species_names[:])*self.n_points
-        
+
         # Save indices for any algebraic variables.
         self.algvars = self.SV_offset + self.SVptr['phi']
 
@@ -98,7 +109,7 @@ class separator():
 
         This is an array of differential and algebraic governing equations, one for each state variable in the separator.
 
-        1. The electric potentials are algebraic variables, and must be such that the ionic current is spatially invariant (i.e. it is constant and equal to the external applied current, for galvanostatic simulations).  
+        1. The electric potentials are algebraic variables, and must be such that the ionic current is spatially invariant (i.e. it is constant and equal to the external applied current, for galvanostatic simulations).
 
         The residual corresponding to these variables (suppose an index 'j') are of the form:
             resid[j]  = (epression equaling zero; in this case i_io[j] - i_ext)
@@ -123,42 +134,42 @@ class separator():
         # Initialize the residual vector, assuming dSVdt = 0 (we will overwrite/
         #  replace this, as necessary)
         resid = SVdot[self.SVptr['sep']]
-        
-        # Calculate the electrolyte species fluxes and the corresponding ionic 
+
+        # Calculate the electrolyte species fluxes and the corresponding ionic
         # current at the anode boundary:
-        N_k_elyte_in, i_io_in = self.electrode_boundary_flux(SV, an, 
+        N_k_elyte_in, i_io_in = self.electrode_boundary_flux(SV, an,
             params['T'])
-        
+
         # The ionic current must equal the external current.
         # resid[self.SVptr['phi'][0]] = i_io - params['i_ext']
-        
+
         # Repeat this for the electric potential in the other separator nodes:
         for j in np.arange(self.n_points-1):
-            # Calculate the electrolyte species fluxes and the corresponding 
-            # ionic current at the boundary between this separator node and the 
+            # Calculate the electrolyte species fluxes and the corresponding
+            # ionic current at the boundary between this separator node and the
             # next one toward the cathode:
             N_k_elyte_out, i_io_out = self.elyte_flux(SV_loc, j, params['T'])
-            
+
             # The ionic current must equal the external current.
             resid[self.SVptr['phi'][j]] = i_io_in - i_io_out# - params['i_ext']
-            
+
             resid[self.SVptr['C_k_elyte'][j]] = \
-                (SVdot_loc[self.SVptr['C_k_elyte'][j]] 
+                (SVdot_loc[self.SVptr['C_k_elyte'][j]]
                 - (N_k_elyte_in - N_k_elyte_out) * self.dyInv / self.eps_elyte)
-            
+
             N_k_elyte_in, i_io_in = N_k_elyte_out, i_io_out
 
-        j = self.n_points-1   
-        N_k_elyte_out, i_io_out = self.electrode_boundary_flux(SV, ca, 
+        j = self.n_points-1
+        N_k_elyte_out, i_io_out = self.electrode_boundary_flux(SV, ca,
             params['T'])
 
         resid[self.SVptr['C_k_elyte'][j]] = \
-            (SVdot_loc[self.SVptr['C_k_elyte'][j]] 
-            - (N_k_elyte_in - N_k_elyte_out) * self.dyInv / self.eps_elyte) 
+            (SVdot_loc[self.SVptr['C_k_elyte'][j]]
+            - (N_k_elyte_in - N_k_elyte_out) * self.dyInv / self.eps_elyte)
 
         # The ionic current must equal the external current.
         resid[self.SVptr['phi'][j]] = i_io_in - i_io_out
-        
+
         return resid
 
     def electrode_boundary_flux(self, SV, ed, T):
@@ -183,7 +194,7 @@ class separator():
             j_elyte = -1
 
         # Determine the electrolyte properties in the separator and electrode domains. Let the separator be "state_1," the electrode "state_2"
-        
+
         # Elyte electric potential in separator:
         phi_1 = SV[self.SVptr['sep'][self.SVptr['phi'][j_elyte]]]
 
@@ -191,18 +202,18 @@ class separator():
         phi_ed = SV[ed.SVptr['electrode'][ed.SVptr['phi_ed'][j_ed]]]
         phi_dl = SV[ed.SVptr['electrode'][ed.SVptr['phi_dl'][j_ed]]]
         phi_2 = phi_ed + phi_dl
-        
+
         C_k_1 = SV[self.SVptr['sep'][self.SVptr['C_k_elyte'][j_elyte]]]
         C_k_2 = SV[ed.SVptr['electrode'][ed.SVptr['C_k_elyte'][j_ed]]]
 
         # Create dictionaries to pass to the transport function:
-        state_1 = {'C_k': C_k_1, 'phi':phi_1, 'T':T, 'dy':self.dy, 
+        state_1 = {'C_k': C_k_1, 'phi':phi_1, 'T':T, 'dy':self.dy,
             'microstructure':self.elyte_microstructure}
-        state_2 = {'C_k': C_k_2, 'phi':phi_2, 'T':T, 'dy':ed.dy_elyte, 
+        state_2 = {'C_k': C_k_2, 'phi':phi_2, 'T':T, 'dy':ed.dy_elyte,
             'microstructure':ed.elyte_microstructure}
 
         # Multiply by ed.i_ext_flag: fluxes are out of the anode, into the cathode.
-        N_k_elyte, i_io = tuple(x*ed.i_ext_flag 
+        N_k_elyte, i_io = tuple(x*ed.i_ext_flag
             for x in self.elyte_transport(state_1, state_2, self))
 
         return N_k_elyte, i_io
@@ -231,9 +242,9 @@ class separator():
         C_k_2 = SV[self.SVptr['C_k_elyte'][j+1]]
 
         # Create dictionaries to pass to the transport function:
-        state_1 = {'C_k': C_k_1, 'phi':phi_1, 'T':T, 'dy':self.dy, 
+        state_1 = {'C_k': C_k_1, 'phi':phi_1, 'T':T, 'dy':self.dy,
             'microstructure':self.elyte_microstructure}
-        state_2 = {'C_k': C_k_2, 'phi':phi_2, 'T':T, 'dy':self.dy, 
+        state_2 = {'C_k': C_k_2, 'phi':phi_2, 'T':T, 'dy':self.dy,
             'microstructure':self.elyte_microstructure}
 
         N_k_elyte, i_io = self.elyte_transport(state_1, state_2, self)
@@ -241,21 +252,21 @@ class separator():
         return N_k_elyte, i_io
 
     def output(self, axs, solution, an, ca, SV_offset, ax_offset):
-        
+
         phi_elyte_ptr = np.add(self.SV_offset+(self.SVptr['phi']), SV_offset)
-        
-        phi_an = (solution[an.SVptr['phi_ed'][0]+SV_offset,:] 
+
+        phi_an = (solution[an.SVptr['phi_ed'][0]+SV_offset,:]
             + solution[an.SVptr['phi_dl'][0]+SV_offset,:])
         axs[ax_offset].plot(solution[0,:]/3600, phi_an)
         for j in np.arange(self.n_points):
-            axs[ax_offset].plot(solution[0,:]/3600, 
+            axs[ax_offset].plot(solution[0,:]/3600,
                 solution[phi_elyte_ptr[j],:])
-        
+
         phi_ca = \
             (solution[ca.SVptr['electrode'][ca.SVptr['phi_ed'][0]]+SV_offset,:] + solution[ca.SVptr['electrode'][ca.SVptr['phi_dl'][0]]+SV_offset,:])
         axs[ax_offset].plot(solution[0,:]/3600, phi_ca)
         axs[ax_offset].set_ylabel('Separator Potential \n(V)')
-        
+
         # Axis 5: Li+ concentration:
         Ck_elyte_an = solution[an.SVptr['C_k_elyte'][0]+SV_offset,:]
         axs[ax_offset+1].plot(solution[0,:]/3600, Ck_elyte_an[an.index_Li,:],
@@ -264,14 +275,14 @@ class separator():
         Ck_elyte_sep_ptr = \
             np.add(self.SV_offset+self.SVptr['C_k_elyte'],SV_offset)
         for j in np.arange(self.n_points):
-            axs[ax_offset+1].plot(solution[0,:]/3600, 
-                solution[Ck_elyte_sep_ptr[j, self.index_Li],:], 
+            axs[ax_offset+1].plot(solution[0,:]/3600,
+                solution[Ck_elyte_sep_ptr[j, self.index_Li],:],
                 label="separator "+str(j+1))
 
         for j in range(int(ca.n_points)):
             Ck_elyte_ca = \
                 solution[ca.SV_offset+ca.SVptr['C_k_elyte'][j]+SV_offset,:]
-            axs[ax_offset+1].plot(solution[0,:]/3600, 
+            axs[ax_offset+1].plot(solution[0,:]/3600,
                 Ck_elyte_ca[ca.index_Li,:])
 
         axs[ax_offset+1].set_ylabel('Li+ concentration \n(kmol/m$^3$')
@@ -294,6 +305,6 @@ class separator():
             local_eval = min(SV_loc[SVptr['C_k_elyte'][j,:]]) - val
             species_eval = min(species_eval, local_eval)
 
-        # The simulation  looks for instances where this value changes sign 
-        # (i.e. where it crosses zero)    
+        # The simulation  looks for instances where this value changes sign
+        # (i.e. where it crosses zero)
         return species_eval

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -11,12 +11,12 @@ def dilute_solution(state_1, state_2, sep):
     T_int = ((state_2['dy'] * state_1['T'] + state_1['dy'] * state_2['T'])
         * dy_inv)
 
-    D_scale_1 = scale_Diff(state_1['C_k'], sep)
-    D_scale_2 = scale_Diff(state_2['C_k'], sep)
+    D_scale_1 = sep.scale_diff(state_1['C_k'], sep)
+    D_scale_2 = sep.scale_diff(state_2['C_k'], sep)
 
     D_k_scale_1 = sep.D_k - D_scale_1
     D_k_scale_2 = sep.D_k - D_scale_2
-    
+
     D_k_eff = (state_2['dy']*D_k_scale_1*state_1['microstructure'] + state_1['dy']*D_k_scale_2*state_2['microstructure'])*dy_inv
 
     D_k_mig = (D_k_eff * sep.elyte_obj.charges * ct.faraday * C_k_int
@@ -31,10 +31,14 @@ def dilute_solution(state_1, state_2, sep):
 
     return N_k_elyte, i_io
 
-def scale_Diff(C_k, sep):
+def scale_diff_zhang(C_k, sep):
     D_vec = np.zeros_like(C_k)
     C_Li = C_k[sep.index_Li] + sep.flag_lithiated*2*np.sum(C_k[4:])
     D_scale = sep.D_scale_coeff*abs(sep.C_Li_0 - C_Li)
     D_vec[sep.index_Li] = D_scale
 
+    return D_vec
+
+def scale_diff_ideal(C_k, sep):
+    D_vec = np.zeros_like(sep.D_k)
     return D_vec

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -32,6 +32,9 @@ def dilute_solution(state_1, state_2, sep):
     return N_k_elyte, i_io
 
 def scale_diff_zhang(C_k, sep):
+    # Concentration dependent diffusion scaling based on the model used in
+    #   Zhang T., Marinescu M., O'Neill L., Wild M. and Offer G. 2015
+    #   Phys. Chem. Chem. Phys. 17 22581
     D_vec = np.zeros_like(C_k)
     C_Li = C_k[sep.index_Li] + sep.flag_lithiated*2*np.sum(C_k[4:])
     D_scale = sep.D_scale_coeff*abs(sep.C_Li_0 - C_Li)

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -10,15 +10,15 @@ def dilute_solution(state_1, state_2, sep):
         * dy_inv)
     T_int = ((state_2['dy'] * state_1['T'] + state_1['dy'] * state_2['T'])
         * dy_inv)
-    D_scale = scale_Diff(C_k_int, sep)
+
     D_scale_1 = scale_Diff(state_1['C_k'], sep)
     D_scale_2 = scale_Diff(state_2['C_k'], sep)
+
     D_k_scale_1 = sep.D_k - D_scale_1
     D_k_scale_2 = sep.D_k - D_scale_2
+    
     D_k_eff = (state_2['dy']*D_k_scale_1*state_1['microstructure'] + state_1['dy']*D_k_scale_2*state_2['microstructure'])*dy_inv
-    #D_k_scale = sep.D_k - D_scale
-    #D_k_eff = ((state_2['dy'] * state_1['microstructure']
-    #    + state_1['dy'] * state_2['microstructure']) * D_k_scale * dy_inv)
+
     D_k_mig = (D_k_eff * sep.elyte_obj.charges * ct.faraday * C_k_int
         / ct.gas_constant / T_int)
 

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -17,7 +17,8 @@ def dilute_solution(state_1, state_2, sep):
     D_k_scale_1 = sep.D_k - D_scale_1
     D_k_scale_2 = sep.D_k - D_scale_2
 
-    D_k_eff = (state_2['dy']*D_k_scale_1*state_1['microstructure'] + state_1['dy']*D_k_scale_2*state_2['microstructure'])*dy_inv
+    D_k_eff = (state_2['dy']*D_k_scale_1*state_1['microstructure'] +
+                state_1['dy']*D_k_scale_2*state_2['microstructure'])*dy_inv
 
     D_k_mig = (D_k_eff * sep.elyte_obj.charges * ct.faraday * C_k_int
         / ct.gas_constant / T_int)

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -4,23 +4,37 @@ import cantera as ct
 import numpy as np
 
 def dilute_solution(state_1, state_2, sep):
-    dy_inv = 1. / (state_1['dy'] + state_2['dy'])
+    dy_inv = 1. / ((state_1['dy'] + state_2['dy']))
 
-    C_k_int = ((state_1['dy'] * state_1['C_k'] + state_2['dy'] * state_2['C_k'])
+    C_k_int = ((state_2['dy'] * state_1['C_k'] + state_1['dy'] * state_2['C_k'])
         * dy_inv)
-    T_int = ((state_1['dy'] * state_1['T'] + state_2['dy'] * state_2['T'])
+    T_int = ((state_2['dy'] * state_1['T'] + state_1['dy'] * state_2['T'])
         * dy_inv)
-
-    D_k_eff = ((state_1['dy'] * state_1['microstructure'] 
-        + state_2['dy'] * state_2['microstructure']) * sep.D_k * dy_inv)
+    D_scale = scale_Diff(C_k_int, sep)
+    D_scale_1 = scale_Diff(state_1['C_k'], sep)
+    D_scale_2 = scale_Diff(state_2['C_k'], sep)
+    D_k_scale_1 = sep.D_k - D_scale_1
+    D_k_scale_2 = sep.D_k - D_scale_2
+    D_k_eff = (state_2['dy']*D_k_scale_1*state_1['microstructure'] + state_1['dy']*D_k_scale_2*state_2['microstructure'])*dy_inv
+    #D_k_scale = sep.D_k - D_scale
+    #D_k_eff = ((state_2['dy'] * state_1['microstructure']
+    #    + state_1['dy'] * state_2['microstructure']) * D_k_scale * dy_inv)
     D_k_mig = (D_k_eff * sep.elyte_obj.charges * ct.faraday * C_k_int
         / ct.gas_constant / T_int)
-    
+
     # Dilute solution theory fluxes:
     N_k_elyte = ((D_k_eff * (state_1['C_k'] - state_2['C_k'])
         + D_k_mig * (state_1['phi'] - state_2['phi'])) * 2 * dy_inv)
-    
+
     # Ionic current = sum(z_k*N_k*F)
     i_io = ct.faraday*np.dot(N_k_elyte, sep.elyte_obj.charges)
 
     return N_k_elyte, i_io
+
+def scale_Diff(C_k, sep):
+    D_vec = np.zeros_like(C_k)
+    C_Li = C_k[sep.index_Li] + sep.flag_lithiated*2*np.sum(C_k[4:])
+    D_scale = sep.D_scale_coeff*abs(sep.C_Li_0 - C_Li)
+    D_vec[sep.index_Li] = D_scale
+
+    return D_vec


### PR DESCRIPTION
Incorporated the ability to alias a desired function to scale diffusion coefficients based on concentrations in the electrolyte. The two models currently implemented are:

- 'ideal' which applies no concentration dependent scaling to the diffusion coefficients
- 'zhang' which applies Li+/Li concentration dependent scaling for diffusion coefficients given some linear scaling factor