### PR TITLE
Fix multiprocessing in fit routine.

### DIFF
--- a/inputs/LiAir_fitTest_quick.yaml
+++ b/inputs/LiAir_fitTest_quick.yaml
@@ -75,8 +75,8 @@ cell-description:
 
 # Simulation parameters:
 parameters:
-  T: 23 # C
-  P: 101325 # Pa
+  T: 23 C
+  P: 101325 Pa
   # Describe simulation type, parameters, etc.
   initialize: # Calculate a common inititial condition for all steps?
     enable: True


### PR DESCRIPTION
Move the `run` routine out to the global level so that multiProcessing.Pool can pickle it.