### PR TITLE
Update transport for diffusion scaling

### DIFF
--- a/separator_models/porous_separator.py
+++ b/separator_models/porous_separator.py
@@ -27,8 +27,6 @@ class separator():
         # coefficient of -0.5:
         self.elyte_microstructure = self.eps_elyte**1.5
 
-        self.flag_lithiated = inputs['transport']['flag_lithiated']
-
         self.D_scale_coeff = inputs['transport']['D_scale_coeff']
 
         self.index_Li = \
@@ -47,12 +45,19 @@ class separator():
             raise ValueError('Please specify a valid electrolyte transport ',
                 'model.')
 
-        if inputs['transport']['diffusion-scaling'] == 'ideal':
+        if inputs['transport'].get('diffusion-scaling') == 'ideal':
             self.scale_diff = transport.scale_diff_ideal
-        elif inputs['transport']['diffusion-scaling'] == 'zhang':
+        elif inputs['transport'].get('diffusion-scaling') == 'zhang':
             self.scale_diff = transport.scale_diff_zhang
+            self.n_Li_atoms = np.zeros(self.elyte_obj.n_species)
+            for i, species in enumerate(self.elyte_obj.species_names):
+                self.n_Li_atoms[i] = self.elyte_obj.n_atoms(species, 'Li')
+
+            self.C_Li_0 = self.C_k_0[self.index_Li] + \
+                                        np.dot(self.n_Li_atoms, self.C_k_0)
         else:
-            raise ValueError('Please specify a valid diffusion scaling model')
+            print('Warning: No valid diffusion scaling input, using ideal')
+            self.scale_diff = transport.scale_diff_ideal
 
         self.SV_offset = offset
 

--- a/separator_models/porous_separator.py
+++ b/separator_models/porous_separator.py
@@ -27,7 +27,7 @@ class separator():
         # coefficient of -0.5:
         self.elyte_microstructure = self.eps_elyte**1.5
 
-        #self.flag_lithiated = inputs['transport']['flag_lithiated']
+        self.flag_lithiated = inputs['transport']['flag_lithiated']
 
         self.D_scale_coeff = inputs['transport']['D_scale_coeff']
 
@@ -47,23 +47,12 @@ class separator():
             raise ValueError('Please specify a valid electrolyte transport ',
                 'model.')
 
-        try:
-            if inputs['transport']['diffusion-scaling'] == 'ideal':
-                self.scale_diff = transport.scale_diff_ideal
-            elif inputs['transport']['diffusion-scaling'] == 'zhang':
-                self.scale_diff = transport.scale_diff_zhang
-                self.n_Li_atoms = np.zeros(self.elyte_obj.n_species)
-                for i, species in enumerate(self.elyte_obj.species_names):
-                    self.n_Li_atoms[i] = self.elyte_obj.n_atoms(species, 'Li')
-
-                self.C_Li_0 = self.C_k_0[self.index_Li] + \
-                                            np.dot(self.n_Li_atoms, self.C_k_0)
-            else:
-                raise ValueError('Please specify a valid diffusion scaling model')
-        except:
-            print('Warning: No diffusion scaling model input, using ideal')
+        if inputs['transport']['diffusion-scaling'] == 'ideal':
             self.scale_diff = transport.scale_diff_ideal
-            
+        elif inputs['transport']['diffusion-scaling'] == 'zhang':
+            self.scale_diff = transport.scale_diff_zhang
+        else:
+            raise ValueError('Please specify a valid diffusion scaling model')
 
         self.SV_offset = offset
 
@@ -280,8 +269,8 @@ class separator():
 
         # Axis 5: Li+ concentration:
         Ck_elyte_an = solution[an.SVptr['C_k_elyte'][0]+SV_offset,:]
-        axs[ax_offset+1].plot(solution[0,:]/3600, Ck_elyte_an[an.index_Li,:],
-            label="an interface")
+        axs[ax_offset+1].plot(solution[0,:]/3600,
+            Ck_elyte_an[an.index_Li_elyte,:], label="an interface")
 
         Ck_elyte_sep_ptr = \
             np.add(self.SV_offset+self.SVptr['C_k_elyte'],SV_offset)
@@ -294,7 +283,7 @@ class separator():
             Ck_elyte_ca = \
                 solution[ca.SV_offset+ca.SVptr['C_k_elyte'][j]+SV_offset,:]
             axs[ax_offset+1].plot(solution[0,:]/3600,
-                Ck_elyte_ca[ca.index_Li,:])
+                Ck_elyte_ca[ca.index_Li_elyte,:])
 
         axs[ax_offset+1].set_ylabel('Li+ concentration \n(kmol/m$^3$')
 

--- a/submodels/transport.py
+++ b/submodels/transport.py
@@ -37,21 +37,21 @@ def scale_diff_zhang(C_k, sep):
     #   Zhang T., Marinescu M., O'Neill L., Wild M. and Offer G. 2015
     #   Phys. Chem. Chem. Phys. 17 22581
     D_vec = np.zeros_like(C_k)
-    #TODO #63 
-    C_Li = C_k[sep.index_Li] + sep.flag_lithiated*2*np.sum(C_k[4:])
+    #TODO #63
+    C_Li = np.dot(sep.n_Li_atoms, C_k)
     D_scale = sep.D_scale_coeff*abs(sep.C_Li_0 - C_Li)
     D_vec[sep.index_Li] = D_scale
 
     return D_vec
 
 def scale_diff_ideal(C_k, sep):
-    # For the ideal case, 
+    # For the ideal case,
     D_vec = np.zeros_like(sep.D_k)
     return D_vec
 
 def radial_flux(C_k, sdot_k, ed):
     # Radial flux of intercalated Li.
-    #   C_k: matrix of electrode species concentrations [kmol/m3]. One array 
+    #   C_k: matrix of electrode species concentrations [kmol/m3]. One array
     #       per radial volume.
     #   sdot_k: species production rates at particle surface (kmol/m2/s)
     #   ed: electrode object
@@ -60,8 +60,8 @@ def radial_flux(C_k, sdot_k, ed):
     N_r_Li = np.zeros((ed.n_r + 1, ed.bulk_obj.n_species))
     N_r_Li[1:-1,:] = (C_k[:-1,:] - C_k[1:,:]) * ed.D_k / ed.dr[:-1]
 
-    # Flux at the surface (in positive r direction) is equal and opposite to 
+    # Flux at the surface (in positive r direction) is equal and opposite to
     #   the production rate from surface reactions:
     N_r_Li[-1,:] = -sdot_k
-    
+
     return N_r_Li


### PR DESCRIPTION
Generalized calculation of number of Li atoms that is used for Zhang diffusion scaling which should fix #63  and added try/except for the diffusion scaling initialization in porous_separator to allow for the diffusion-scaling field not being present in yaml input files.